### PR TITLE
Update top-pypi-packages filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Now you can use `compute_tool.py`/`compute_tools.py` to run queries over the dat
 Download the top packages list (monthly):
 
 ```bash
-wget https://hugovk.github.io/top-pypi-packages/top-pypi-packages-30-days.min.json
+wget https://hugovk.github.io/top-pypi-packages/top-pypi-packages.min.json
 ```
 
 ## Print counts

--- a/count.py
+++ b/count.py
@@ -1,6 +1,6 @@
 import json
 
-with open("top-pypi-packages-30-days.min.json") as f:
+with open("top-pypi-packages.min.json") as f:
     j = json.load(f)
 
 projs = {l["project"]: (i, l["download_count"]) for i, l in enumerate(j["rows"])}

--- a/pyready/README.md
+++ b/pyready/README.md
@@ -10,5 +10,5 @@ uv run pymodel.py myproj.json
 You can get a list of the top packages from the parent folder with:
 
 ```bash
-jq -r '.rows[:360] | .[] | .project' top-pypi-packages-30-days.min.json > pyready/top360.txt
+jq -r '.rows[:360] | .[] | .project' top-pypi-packages.min.json > pyready/top360.txt
 ```


### PR DESCRIPTION
To stay within quota, it now has just under 30 days of data, so the filename has been updated. Both will be available for a while. See https://github.com/hugovk/top-pypi-packages/pull/46.